### PR TITLE
Fix broken install key check

### DIFF
--- a/lib/puppet/parser/functions/fingerprint_formatter.rb
+++ b/lib/puppet/parser/functions/fingerprint_formatter.rb
@@ -1,4 +1,5 @@
 # A custom function to take fingerprints and format them for comparing against `apt-key fingerprint`
+# fingerprint_formatter("6F6B15509CF8E59E6E469F327F438280EF8D349F") == "6F6B 1550 9CF8 E59E 6E46  9F32 7F43 8280 EF8D 349F"
 module Puppet::Parser::Functions
   newfunction(:fingerprint_formatter, type: :rvalue) do |args|
     fingerprint = args[0]
@@ -15,6 +16,8 @@ module Puppet::Parser::Functions
       ending += 4
     end
 
-    "#{broken_up[0..4].join(" ")}  #{broken_up[5..10].join(" ")}"
+    fingerprint_broken_up.map! { |section| section.join }
+
+    "#{fingerprint_broken_up[0..4].join(" ")}  #{fingerprint_broken_up[5..10].join(" ")}"
   end
 end

--- a/lib/puppet/parser/functions/fingerprint_formatter.rb
+++ b/lib/puppet/parser/functions/fingerprint_formatter.rb
@@ -1,0 +1,20 @@
+# A custom function to take fingerprints and format them for comparing against `apt-key fingerprint`
+module Puppet::Parser::Functions
+  newfunction(:fingerprint_formatter, type: :rvalue) do |args|
+    fingerprint = args[0]
+
+    if fingerprint.nil?
+      raise Puppet::ParseError, 'fingerprint_formatter requires a fingerprint to format as an argument.'
+    end
+
+    fingerprint_broken_up = []
+    beginning, ending = 0, 3
+    10.times do
+      fingerprint_broken_up << fingerprint.split('')[beginning..ending]
+      beginning += 4
+      ending += 4
+    end
+
+    "#{broken_up[0..4].join(" ")}  #{broken_up[5..10].join(" ")}"
+  end
+end

--- a/manifests/ubuntu/install_key.pp
+++ b/manifests/ubuntu/install_key.pp
@@ -17,6 +17,6 @@ define datadog_agent::ubuntu::install_key() {
 
   exec { "key ${name}":
     command => "/usr/bin/apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${name}",
-    unless  => "/usr/bin/apt-key fingerprint | grep -B 1 ${formatted_name} | grep expires",
+    unless  => "/usr/bin/apt-key fingerprint | grep -B 1 '${formatted_name}' | grep expires",
   }
 }

--- a/manifests/ubuntu/install_key.pp
+++ b/manifests/ubuntu/install_key.pp
@@ -13,8 +13,10 @@
 #
 #
 define datadog_agent::ubuntu::install_key() {
+  $formatted_name = fingerprint_formatter($name)
+
   exec { "key ${name}":
     command => "/usr/bin/apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${name}",
-    unless  => "/usr/bin/apt-key list | grep ${name} | grep expires",
+    unless  => "/usr/bin/apt-key fingerprint | grep -B 1 ${formatted_name} | grep expires",
   }
 }


### PR DESCRIPTION
Currently, we place the datadog install key every puppet run:

```
Notice: /Stage[main]/Datadog_agent::Ubuntu/Datadog_agent::Ubuntu::Install_key[935F5A436A5A6E8788F0765B226AE980C7A7DA52]/Exec[key 935F5A436A5A6E8788F0765B226AE980C7A7DA52]/returns: executed successfully
Notice: /Stage[main]/Datadog_agent::Ubuntu/Datadog_agent::Ubuntu::Install_key[A2923DFF56EDA6E76E55E492D3A80E30382E94DE]/Exec[key A2923DFF56EDA6E76E55E492D3A80E30382E94DE]/returns: executed successfully
```

This fixes that.