### PR TITLE
Add a count metric for the number of times Puppet has run.

### DIFF
--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -116,6 +116,8 @@ Puppet::Reports.register_report(:datadog_reports) do
           @dog.emit_point("#{name}", value, :host => "#{@msg_host}")
         }
       }
+
+      @dog.emit_point("puppet.runs", 1, :type => "counter", :host => "#{@msg_host}")
     end
 
     Puppet.debug "Sending events for #{@msg_host} to Datadog"


### PR DESCRIPTION
This PR is a bit strange as I'm requesting review of both the target branch and the changes to be merged into it.

## The `procore-1.x` Branch

The procore/puppet `Puppetfile` currently points to the tip of the `fsf/specify_ca_cert` branch in this repository. That branch is derived from an arbitrary point on the upstream `master` branch during the 1.x major version. Its changes have been merged upstream in 2.x, but not in 1.x. To create the `procore-1.x` branch that is the target of this PR I started from the latest upstream 1.x release and merged our `fsf/specify_ca_cert` branch. I intend for that branch to be the target in the `Puppetfile` until we're ready to upgrade to datadog-agent 6.x.

I originally intended to upgrade us to puppet-datadog-agent 2.x, but it requires much newer versions of some of the core puppetlabs dependencies and I didn't want to sort that out on procore/puppet as part of this task. It can wait until we actually need 2.x in order to install agent 6.x.

## This Change

puppet-datadog-agent includes a Puppet report processor which sends metrics and events about the Puppet run to Datadog. This modifies that code to include an additional metric which counts the number of times Puppet has been run.

The reporter already reports an event to Datadog at the end of every run, and I originally hoped to use those events as a way to build a monitor to detect hosts that aren't applying Puppet. Unfortunately Datadog doesn't have a mechanism to alert on hosts which are **not** sending a particular event. The metric I'm adding here will allow me to alert on that condition using the "No Data" state of a metric monitor.

I've had this branch running on `utility1.us00.procore.staging1` since Friday and it appears to be doing what I intended. You can view the resulting metrics in this Datadog notebook:
https://app.datadoghq.com/notebook/136733/puppet.runs%20test